### PR TITLE
Fix typo

### DIFF
--- a/freecad/stemfie/Plates.py
+++ b/freecad/stemfie/Plates.py
@@ -271,7 +271,7 @@ class PLT_HEX:
             QT_TRANSLATE_NOOP("App::Property", "RingsNumber"),
             QT_TRANSLATE_NOOP("App::Property", "Part parameters"),
             QT_TRANSLATE_NOOP(
-                "App::Property", "Number of rings araound central hole \nMinimum = 1"
+                "App::Property", "Number of rings around central hole \nMinimum = 1"
             ),
         ).RingsNumber = 2
 


### PR DESCRIPTION
Found via `codespell  -q 3 -S "*.odt,*.ts"`